### PR TITLE
Feature/mqtt2mqtt worker topics

### DIFF
--- a/conf/mqtt.yaml
+++ b/conf/mqtt.yaml
@@ -4,6 +4,11 @@ outgoingPublishingEnabled: true
 outgoingClientQoS: 0
 outgoingClientRetainedMessages: false
 
+#Physical Device Broker Parameters
+brokerAddress: 127.0.0.1
+brokerPort: 1883
+brokerLocal: true
+
 #Destination Broker Parameters
 destinationBrokerAddress: 127.0.0.1
 destinationBrokerPort: 1884
@@ -11,38 +16,14 @@ destinationBrokerPort: 1884
 #e.g., digitaltwin (without the final /)
 destinationBrokerBaseTopic: null
 
-#Physical object references. Used if the DTDP Module is not active
-#deviceId: "it.unimore.dipi.things:dummy_device:0be64e3d-985d-43f2-b810-10e8e1d6862a"
-#resourceIdList:
-#  - "dummy_sensor:58d4f33a-adc8-4317-8717-0848e9747d33-1"
-#  - "dummy_sensor:7ea88f66-02c6-4525-97a9-dc279b6ef66b-0"
-#deviceTelemetryTopic: "telemetry/{{device_id}}"
-#resourceTelemetryTopic: "telemetry/{{device_id}}/resource/{{resource_id}}"
-#eventTopic: "events/{{device_id}}"
-#commandRequestTopic: "commands/{{device_id}}/request"
-#commandResponseTopic: "commands/{{device_id}}/response"
-#brokerAddress: 127.0.0.1
-#brokerPort: 1883
-#brokerLocal: true
-
 deviceId: "it.unimore.dipi.things:dummy_device:0be64e3d-985d-43f2-b810-10e8e1d6862a"
-resourceIdList: null
-deviceTelemetryTopic: "number"
-resourceTelemetryTopic: null
-eventTopic: null
-commandRequestTopic: null
-commandResponseTopic: null
-brokerAddress: 127.0.0.1
-brokerPort: 1883
-brokerLocal: true
 
-#MQTT Processing Pipeline Configuration
-deviceTelemetryProcessingStepList:
-  - "IdentityProcessingStep"
-  #- "MqttAverageProcessingStep"
-  #- "MqttSenmlBuilderProcessingStep"
-resourceTelemetryProcessingStepList:
-  - "IdentityProcessingStep"
-eventProcessingStepList:
-  - "IdentityProcessingStep"
-commandRequestProcessingStepList: null
+topicList:
+    - id: gpsTelemetryTopic
+      resourceId: gps
+      topic: /topic/iot/device/test/{{device_id}}/gps
+      type: device_outgoing
+    - id: batteryTelemetryTopic
+      resourceId: battery
+      topic: /topic/iot/device/test/{{device_id}}/battery
+      type: device_outgoing

--- a/conf/mqtt.yaml
+++ b/conf/mqtt.yaml
@@ -1,7 +1,7 @@
 dtForwardingEnabled: true
 
-#MQTT Ougoing Client Parameters
-outgoingClientQoS: 0
+#DT's publishing QoS
+dtPublishingQoS: 0
 
 #Physical Device Broker Parameters
 brokerAddress: 127.0.0.1

--- a/conf/mqtt.yaml
+++ b/conf/mqtt.yaml
@@ -1,13 +1,15 @@
-outgoingPublishingEnabled: true
+dtForwardingEnabled: true
 
 #MQTT Ougoing Client Parameters
 outgoingClientQoS: 0
-outgoingClientRetainedMessages: false
 
 #Physical Device Broker Parameters
 brokerAddress: 127.0.0.1
 brokerPort: 1883
 brokerLocal: true
+
+#It is applied both to incoming and outgoing DT's topics
+dtTopicPrefix: "wldt"
 
 #Destination Broker Parameters
 destinationBrokerAddress: 127.0.0.1

--- a/conf/mqtt_old.yaml
+++ b/conf/mqtt_old.yaml
@@ -1,0 +1,48 @@
+outgoingPublishingEnabled: true
+
+#MQTT Ougoing Client Parameters
+outgoingClientQoS: 0
+outgoingClientRetainedMessages: false
+
+#Destination Broker Parameters
+destinationBrokerAddress: 127.0.0.1
+destinationBrokerPort: 1884
+
+#e.g., digitaltwin (without the final /)
+destinationBrokerBaseTopic: null
+
+#Physical object references. Used if the DTDP Module is not active
+#deviceId: "it.unimore.dipi.things:dummy_device:0be64e3d-985d-43f2-b810-10e8e1d6862a"
+#resourceIdList:
+#  - "dummy_sensor:58d4f33a-adc8-4317-8717-0848e9747d33-1"
+#  - "dummy_sensor:7ea88f66-02c6-4525-97a9-dc279b6ef66b-0"
+#deviceTelemetryTopic: "telemetry/{{device_id}}"
+#resourceTelemetryTopic: "telemetry/{{device_id}}/resource/{{resource_id}}"
+#eventTopic: "events/{{device_id}}"
+#commandRequestTopic: "commands/{{device_id}}/request"
+#commandResponseTopic: "commands/{{device_id}}/response"
+#brokerAddress: 127.0.0.1
+#brokerPort: 1883
+#brokerLocal: true
+
+deviceId: "it.unimore.dipi.things:dummy_device:0be64e3d-985d-43f2-b810-10e8e1d6862a"
+resourceIdList: null
+deviceTelemetryTopic: "number"
+resourceTelemetryTopic: null
+eventTopic: null
+commandRequestTopic: null
+commandResponseTopic: null
+brokerAddress: 127.0.0.1
+brokerPort: 1883
+brokerLocal: true
+
+#MQTT Processing Pipeline Configuration
+deviceTelemetryProcessingStepList:
+  - "IdentityProcessingStep"
+  #- "MqttAverageProcessingStep"
+  #- "MqttSenmlBuilderProcessingStep"
+resourceTelemetryProcessingStepList:
+  - "IdentityProcessingStep"
+eventProcessingStepList:
+  - "IdentityProcessingStep"
+commandRequestProcessingStepList: null

--- a/conf/wldt.yaml
+++ b/conf/wldt.yaml
@@ -6,7 +6,6 @@ wldtStartupTimeSeconds: 10
 
 #Active Protocol Modules List (enabled if DTDP Discovery is set to false)
 activeProtocolList:
-  - coap
   - mqtt
 
 #Application Metrics

--- a/src/main/java/it/unimore/dipi/iot/wldt/engine/WldtEngine.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/engine/WldtEngine.java
@@ -109,6 +109,7 @@ public class WldtEngine {
             throw new WldtConfigurationException("Empty enabled protocol list !");
 
         this.workerList.forEach(wldtWorker -> {
+            logger.info("Executing worker: {}", wldtWorker.getClass());
             executor.execute(wldtWorker);
         });
 
@@ -131,7 +132,7 @@ public class WldtEngine {
         else {
             for(String protocolId: this.wldtConfiguration.getActiveProtocolList()){
                 if(protocolId.equals(WorkerIdentifier.MQTT_TO_MQTT_MODULE.value))
-                    this.addNewWorker(new Mqtt2MqttWorker(this.getWldtId(), this.wldtConfiguration));
+                    this.addNewWorker(new Mqtt2MqttWorker(this.getWldtId()));
                 if(protocolId.equals(WorkerIdentifier.COAP_TO_COAP_MODULE.value))
                     this.addNewWorker(new Coap2CoapWorker());
             }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapManagerMissingDeviceInfoException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapManagerMissingDeviceInfoException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 24/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtCoapManagerMissingDeviceInfoException extends Throwable {
+public class WldtCoapManagerMissingDeviceInfoException extends Exception {
     public WldtCoapManagerMissingDeviceInfoException(String s) {
         super(s);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapModuleException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapModuleException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 24/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtCoapModuleException extends Throwable {
+public class WldtCoapModuleException extends Exception {
     public WldtCoapModuleException(String s) {
         super(s);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapResourceDiscoveryException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapResourceDiscoveryException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 24/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtCoapResourceDiscoveryException extends Throwable {
+public class WldtCoapResourceDiscoveryException extends Exception {
     public WldtCoapResourceDiscoveryException(String s) {
         super(s);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapResourceException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtCoapResourceException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 24/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtCoapResourceException extends Throwable {
+public class WldtCoapResourceException extends Exception {
     public WldtCoapResourceException(String s) {
         super(s);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtConfigurationException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtConfigurationException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 24/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtConfigurationException extends Throwable {
+public class WldtConfigurationException extends Exception {
 
     public WldtConfigurationException(String s) {
         super(s);

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtMqttModuleException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtMqttModuleException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 27/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtMqttModuleException extends Throwable {
+public class WldtMqttModuleException extends Exception {
     public WldtMqttModuleException(String s) {
         super(s);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtRuntimeException.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/exception/WldtRuntimeException.java
@@ -5,7 +5,7 @@ package it.unimore.dipi.iot.wldt.exception;
  * Date: 27/03/2020
  * Project: White Label Digital Twin Java Framework - (whitelabel-digitaltwin)
  */
-public class WldtRuntimeException extends Throwable {
+public class WldtRuntimeException extends Exception {
     public WldtRuntimeException(String errorMsg) {
         super(errorMsg);
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/metrics/WldtMetricsManager.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/metrics/WldtMetricsManager.java
@@ -36,7 +36,7 @@ public class WldtMetricsManager {
 
     public static final String MQTT_EVENT_FORWARD_TIME = "event_forward_time";
 
-    public static final String MQTT_TELEMETRY_FORWARD_TIME = "telemetry_forward_time";
+    public static final String MQTT_FORWARD_TIME = "mqtt_forward_time";
 
     public static final String MQTT_COMMAND_REQUEST_FORWARD_TIME = "command_request_forward_time";
 

--- a/src/main/java/it/unimore/dipi/iot/wldt/process/WldtCoapProcess.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/process/WldtCoapProcess.java
@@ -40,7 +40,7 @@ public class WldtCoapProcess {
             wldtEngine.addNewWorker(new Coap2CoapWorker(getCoapProtocolConfiguration()));
             wldtEngine.startWorkers();
 
-        }catch (Exception | WldtConfigurationException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/process/WldtDummyProcess.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/process/WldtDummyProcess.java
@@ -67,7 +67,7 @@ public class WldtDummyProcess {
 
             wldtEngine.startWorkers();
 
-        }catch (Exception | WldtConfigurationException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/process/WldtMqttProcess.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/process/WldtMqttProcess.java
@@ -2,14 +2,13 @@ package it.unimore.dipi.iot.wldt.process;
 
 import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
-import it.unimore.dipi.iot.wldt.exception.WldtConfigurationException;
 import it.unimore.dipi.iot.wldt.worker.MirroringListener;
 import it.unimore.dipi.iot.wldt.worker.mqtt.Mqtt2MqttConfiguration;
 import it.unimore.dipi.iot.wldt.worker.mqtt.Mqtt2MqttWorker;
+import it.unimore.dipi.iot.wldt.worker.mqtt.MqttTopicDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -46,30 +45,31 @@ public class WldtMqttProcess {
             mqtt2MqttWorker.addMirroringListener(new MirroringListener() {
 
                 @Override
-                public void onPhysicalDeviceMirrored(String deviceId, Map<String, Object> metadata) {
-                    logger.info("onPhysicalDeviceMirrored() callback ! DeviceId: {} -> Metadata: {}", deviceId, metadata);
+                public void onDeviceMirrored(String deviceId, Map<String, Object> metadata) {
+                    logger.info("onDeviceMirrored() callback ! DeviceId: {} -> Metadata: {}", deviceId, metadata);
                 }
 
                 @Override
-                public void onPhysicalDeviceMirroringError(String deviceId, String errorMsg) {
-                    logger.error("onPhysicalDeviceMirroringError() callback ! Error Mirroring Device: {} Reason: {}", deviceId, errorMsg);
+                public void onDeviceMirroringError(String deviceId, String errorMsg) {
+                    logger.info("onDeviceMirroringError() callback ! DeviceId: {} -> ErrorMsg: {}", deviceId, errorMsg);
                 }
 
                 @Override
-                public void onPhysicalResourceMirrored(String resourceId, Map<String, Object> metadata) {
-                    logger.info("onPhysicalResourceMirrored() callback ! ResourceId: {} -> Metadata: {}", resourceId, metadata);
+                public void onResourceMirrored(String resourceId, Map<String, Object> metadata) {
+                    logger.info("onResourceMirrored() callback ! ResourceId: {} -> Metadata: {}", resourceId, metadata);
                 }
 
                 @Override
-                public void onPhysicalResourceMirroringError(String deviceId, String errorMsg) {
-                    logger.error("onPhysicalResourceMirroringError() callback ! Error Mirroring Resource: {} Reason: {}", deviceId, errorMsg);
+                public void onResourceMirroringError(String resourceId, String errorMsg) {
+                    logger.info("onResourceMirroringError() callback ! ResourceId: {} -> ErrorMsg: {}", resourceId, errorMsg);
                 }
+
             });
 
             wldtEngine.addNewWorker(mqtt2MqttWorker);
             wldtEngine.startWorkers();
 
-        }catch (Exception | WldtConfigurationException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
     }
@@ -86,14 +86,27 @@ public class WldtMqttProcess {
         mqtt2MqttConfiguration.setDestinationBrokerPort(1884);
         mqtt2MqttConfiguration.setDestinationBrokerBaseTopic("wldt");
         mqtt2MqttConfiguration.setDeviceId("com:iot:dummy:dummyMqttDevice001");
-        mqtt2MqttConfiguration.setResourceIdList(Arrays.asList("dummy_string_resource"));
-        mqtt2MqttConfiguration.setDeviceTelemetryTopic("telemetry/{{device_id}}");
-        mqtt2MqttConfiguration.setResourceTelemetryTopic("telemetry/{{device_id}}/resource/{{resource_id}}");
-        mqtt2MqttConfiguration.setEventTopic("events/{{device_id}}");
-        mqtt2MqttConfiguration.setCommandRequestTopic("commands/{{device_id}}/request");
-        mqtt2MqttConfiguration.setCommandResponseTopic("commands/{{device_id}}/response");
         mqtt2MqttConfiguration.setBrokerAddress("127.0.0.1");
         mqtt2MqttConfiguration.setBrokerPort(1883);
+
+        //Specify Topic List Configuration
+        mqtt2MqttConfiguration.setTopicList(
+                Collections.singletonList(
+                        new MqttTopicDescriptor("DummyStringResource",
+                                "dummy_string_resource",
+                                "telemetry/{{device_id}}/resource/{{resource_id}}",
+                                MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_OUTGOING)
+                )
+        );
+
+        //mqtt2MqttConfiguration.setResourceIdList(Arrays.asList("dummy_string_resource"));
+        //mqtt2MqttConfiguration.setDeviceTelemetryTopic("telemetry/{{device_id}}");
+        //mqtt2MqttConfiguration.setResourceTelemetryTopic("telemetry/{{device_id}}/resource/{{resource_id}}");
+        //mqtt2MqttConfiguration.setEventTopic("events/{{device_id}}");
+        //mqtt2MqttConfiguration.setCommandRequestTopic("commands/{{device_id}}/request");
+        //mqtt2MqttConfiguration.setCommandResponseTopic("commands/{{device_id}}/response");
+
+
 
         return mqtt2MqttConfiguration;
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/process/WldtMqttProcess.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/process/WldtMqttProcess.java
@@ -8,7 +8,8 @@ import it.unimore.dipi.iot.wldt.worker.mqtt.Mqtt2MqttWorker;
 import it.unimore.dipi.iot.wldt.worker.mqtt.MqttTopicDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.Collections;
+
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -84,18 +85,22 @@ public class WldtMqttProcess {
         mqtt2MqttConfiguration.setOutgoingClientQoS(0);
         mqtt2MqttConfiguration.setDestinationBrokerAddress("127.0.0.1");
         mqtt2MqttConfiguration.setDestinationBrokerPort(1884);
-        mqtt2MqttConfiguration.setDestinationBrokerBaseTopic("wldt");
+        mqtt2MqttConfiguration.setDtTopicPrefix("wldt");
         mqtt2MqttConfiguration.setDeviceId("com:iot:dummy:dummyMqttDevice001");
         mqtt2MqttConfiguration.setBrokerAddress("127.0.0.1");
         mqtt2MqttConfiguration.setBrokerPort(1883);
 
         //Specify Topic List Configuration
         mqtt2MqttConfiguration.setTopicList(
-                Collections.singletonList(
+                Arrays.asList(
                         new MqttTopicDescriptor("DummyStringResource",
                                 "dummy_string_resource",
                                 "telemetry/{{device_id}}/resource/{{resource_id}}",
-                                MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_OUTGOING)
+                                MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_OUTGOING),
+                        new MqttTopicDescriptor("CommandChannel",
+                                "default_command_channel",
+                                "command/{{device_id}}",
+                                MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_INCOMING)
                 )
         );
 

--- a/src/main/java/it/unimore/dipi/iot/wldt/tester/WldtDtdpTesterProcess.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/tester/WldtDtdpTesterProcess.java
@@ -92,7 +92,7 @@ public class WldtDtdpTesterProcess {
             }
              */
 
-        }catch (Exception | WldtConfigurationException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/utils/WldtUtils.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/utils/WldtUtils.java
@@ -35,7 +35,7 @@ public class WldtUtils {
             return om.readValue(file, targetClass);
 
         }catch (Exception e){
-            String errorMessage = String.format("ERROR LOADING CONFIGURATION FILE ({}) ! Error: %s", confFilename, e.getLocalizedMessage());
+            String errorMessage = String.format("ERROR LOADING CONFIGURATION FILE (%s) ! Error: %s", confFilename, e.getLocalizedMessage());
             logger.error("{}", errorMessage);
             throw new WldtConfigurationException(errorMessage);
         }

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/MirroringListener.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/MirroringListener.java
@@ -9,12 +9,12 @@ import java.util.Map;
  */
 public interface MirroringListener {
 
-    public void onPhysicalDeviceMirrored(String deviceId, Map<String, Object> metadata);
+    public void onDeviceMirrored(String deviceId, Map<String, Object> metadata);
 
-    public void onPhysicalDeviceMirroringError(String deviceId, String errorMsg);
+    public void onDeviceMirroringError(String deviceId, String errorMsg);
 
-    public void onPhysicalResourceMirrored(String resourceId, Map<String, Object> metadata);
+    public void onResourceMirrored(String resourceId, Map<String, Object> metadata);
 
-    public void onPhysicalResourceMirroringError(String deviceId, String errorMsg);
+    public void onResourceMirroringError(String ResourceId, String errorMsg);
 
 }

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/WldtWorker.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/WldtWorker.java
@@ -55,7 +55,7 @@ public abstract class WldtWorker<T, K, V> implements Runnable {
         try {
             initCache();
             startWorkerJob();
-        } catch (WldtConfigurationException | WldtRuntimeException e) {
+        } catch (Exception e) {
             logger.error("WLDT WORKER ERROR: {}", e.getLocalizedMessage());
         }
     }
@@ -166,7 +166,7 @@ public abstract class WldtWorker<T, K, V> implements Runnable {
 
             if(this.mirroringListenerList != null)
                 this.mirroringListenerList.forEach(mirroringListener -> {
-                    mirroringListener.onPhysicalDeviceMirrored(deviceId, metadata);
+                    mirroringListener.onDeviceMirrored(deviceId, metadata);
                 });
 
         }catch (Exception e){
@@ -180,7 +180,7 @@ public abstract class WldtWorker<T, K, V> implements Runnable {
 
             if(this.mirroringListenerList != null)
                 this.mirroringListenerList.forEach(mirroringListener -> {
-                    mirroringListener.onPhysicalResourceMirrored(deviceId, metadata);
+                    mirroringListener.onResourceMirrored(deviceId, metadata);
                 });
 
         }catch (Exception e){
@@ -194,7 +194,7 @@ public abstract class WldtWorker<T, K, V> implements Runnable {
 
             if(this.mirroringListenerList != null)
                 this.mirroringListenerList.forEach(mirroringListener -> {
-                    mirroringListener.onPhysicalDeviceMirroringError(deviceId, errorMsg);
+                    mirroringListener.onDeviceMirroringError(deviceId, errorMsg);
                 });
 
         }catch (Exception e){
@@ -207,7 +207,7 @@ public abstract class WldtWorker<T, K, V> implements Runnable {
 
             if(this.mirroringListenerList != null)
                 this.mirroringListenerList.forEach(mirroringListener -> {
-                    mirroringListener.onPhysicalResourceMirroringError(deviceId, errorMsg);
+                    mirroringListener.onResourceMirroringError(deviceId, errorMsg);
                 });
 
         }catch (Exception e){

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
@@ -10,18 +10,18 @@ import java.util.List;
  */
 public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
 
-    private boolean outgoingPublishingEnabled = true;
+    private boolean dtForwardingEnabled = true;
 
     private int outgoingClientQoS = 0;
-
-    //TODO Check if it is correctly used or can be improved
-    private boolean outgoingClientRetainedMessages = false;
 
     private String destinationBrokerAddress;
 
     private int destinationBrokerPort;
 
-    private String destinationBrokerBaseTopic;
+    /**
+     * It is applied both for outgoing and incoming topics
+     */
+    private String dtTopicPrefix;
 
     private String deviceId = null;
 
@@ -32,36 +32,6 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
     private boolean brokerLocal = true;
 
     private List<MqttTopicDescriptor> topicList;
-
-    @Deprecated
-    private List<String> resourceIdList = null;
-
-    @Deprecated
-    private String deviceTelemetryTopic = null;
-
-    @Deprecated
-    private String resourceTelemetryTopic = null;
-
-    @Deprecated
-    private String eventTopic = null;
-
-    @Deprecated
-    private String commandRequestTopic = null;
-
-    @Deprecated
-    private String commandResponseTopic = null;
-
-    @Deprecated
-    private List<String> deviceTelemetryProcessingStepList = null;
-
-    @Deprecated
-    private List<String> resourceTelemetryProcessingStepList = null;
-
-    @Deprecated
-    private List<String> eventProcessingStepList = null;
-
-    @Deprecated
-    private List<String> commandRequestProcessingStepList = null;
 
     public Mqtt2MqttConfiguration() {
     }
@@ -82,12 +52,12 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
         this.destinationBrokerPort = destinationBrokerPort;
     }
 
-    public String getDestinationBrokerBaseTopic() {
-        return destinationBrokerBaseTopic;
+    public String getDtTopicPrefix() {
+        return dtTopicPrefix;
     }
 
-    public void setDestinationBrokerBaseTopic(String destinationBrokerBaseTopic) {
-        this.destinationBrokerBaseTopic = destinationBrokerBaseTopic;
+    public void setDtTopicPrefix(String dtTopicPrefix) {
+        this.dtTopicPrefix = dtTopicPrefix;
     }
 
     public int getOutgoingClientQoS() {
@@ -98,20 +68,12 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
         this.outgoingClientQoS = outgoingClientQoS;
     }
 
-    public boolean getOutgoingClientRetainedMessages() {
-        return outgoingClientRetainedMessages;
+    public boolean getDtForwardingEnabled() {
+        return dtForwardingEnabled;
     }
 
-    public void setOutgoingClientRetainedMessages(boolean outgoingClientRetainedMessages) {
-        this.outgoingClientRetainedMessages = outgoingClientRetainedMessages;
-    }
-
-    public boolean getOutgoingPublishingEnabled() {
-        return outgoingPublishingEnabled;
-    }
-
-    public void setOutgoingPublishingEnabled(boolean outgoingPublishingEnabled) {
-        this.outgoingPublishingEnabled = outgoingPublishingEnabled;
+    public void setDtForwardingEnabled(boolean dtForwardingEnabled) {
+        this.dtForwardingEnabled = dtForwardingEnabled;
     }
 
     public String getDeviceId() {
@@ -120,54 +82,6 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
 
     public void setDeviceId(String deviceId) {
         this.deviceId = deviceId;
-    }
-
-    public List<String> getResourceIdList() {
-        return resourceIdList;
-    }
-
-    public void setResourceIdList(List<String> resourceIdList) {
-        this.resourceIdList = resourceIdList;
-    }
-
-    public String getDeviceTelemetryTopic() {
-        return deviceTelemetryTopic;
-    }
-
-    public void setDeviceTelemetryTopic(String deviceTelemetryTopic) {
-        this.deviceTelemetryTopic = deviceTelemetryTopic;
-    }
-
-    public String getResourceTelemetryTopic() {
-        return resourceTelemetryTopic;
-    }
-
-    public void setResourceTelemetryTopic(String resourceTelemetryTopic) {
-        this.resourceTelemetryTopic = resourceTelemetryTopic;
-    }
-
-    public String getEventTopic() {
-        return eventTopic;
-    }
-
-    public void setEventTopic(String eventTopic) {
-        this.eventTopic = eventTopic;
-    }
-
-    public String getCommandRequestTopic() {
-        return commandRequestTopic;
-    }
-
-    public void setCommandRequestTopic(String commandRequestTopic) {
-        this.commandRequestTopic = commandRequestTopic;
-    }
-
-    public String getCommandResponseTopic() {
-        return commandResponseTopic;
-    }
-
-    public void setCommandResponseTopic(String commandResponseTopic) {
-        this.commandResponseTopic = commandResponseTopic;
     }
 
     public String getBrokerAddress() {
@@ -194,46 +108,6 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
         this.brokerLocal = brokerLocal;
     }
 
-    @Deprecated
-    public List<String> getDeviceTelemetryProcessingStepList() {
-        return deviceTelemetryProcessingStepList;
-    }
-
-    @Deprecated
-    public void setDeviceTelemetryProcessingStepList(List<String> deviceTelemetryProcessingStepList) {
-        this.deviceTelemetryProcessingStepList = deviceTelemetryProcessingStepList;
-    }
-
-    @Deprecated
-    public List<String> getResourceTelemetryProcessingStepList() {
-        return resourceTelemetryProcessingStepList;
-    }
-
-    @Deprecated
-    public void setResourceTelemetryProcessingStepList(List<String> resourceTelemetryProcessingStepList) {
-        this.resourceTelemetryProcessingStepList = resourceTelemetryProcessingStepList;
-    }
-
-    @Deprecated
-    public List<String> getEventProcessingStepList() {
-        return eventProcessingStepList;
-    }
-
-    @Deprecated
-    public void setEventProcessingStepList(List<String> eventProcessingStepList) {
-        this.eventProcessingStepList = eventProcessingStepList;
-    }
-
-    @Deprecated
-    public List<String> getCommandRequestProcessingStepList() {
-        return commandRequestProcessingStepList;
-    }
-
-    @Deprecated
-    public void setCommandRequestProcessingStepList(List<String> commandRequestProcessingStepList) {
-        this.commandRequestProcessingStepList = commandRequestProcessingStepList;
-    }
-
     public List<MqttTopicDescriptor> getTopicList() {
         return topicList;
     }
@@ -245,27 +119,16 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("Mqtt2MqttConfiguration{");
-        sb.append("outgoingPublishingEnabled=").append(outgoingPublishingEnabled);
+        sb.append("dtForwardingEnabled=").append(dtForwardingEnabled);
         sb.append(", outgoingClientQoS=").append(outgoingClientQoS);
-        sb.append(", outgoingClientRetainedMessages=").append(outgoingClientRetainedMessages);
         sb.append(", destinationBrokerAddress='").append(destinationBrokerAddress).append('\'');
         sb.append(", destinationBrokerPort=").append(destinationBrokerPort);
-        sb.append(", destinationBrokerBaseTopic='").append(destinationBrokerBaseTopic).append('\'');
+        sb.append(", dtTopicPrefix='").append(dtTopicPrefix).append('\'');
         sb.append(", deviceId='").append(deviceId).append('\'');
         sb.append(", brokerAddress='").append(brokerAddress).append('\'');
         sb.append(", brokerPort=").append(brokerPort);
         sb.append(", brokerLocal=").append(brokerLocal);
         sb.append(", topicList=").append(topicList);
-        sb.append(", resourceIdList=").append(resourceIdList);
-        sb.append(", deviceTelemetryTopic='").append(deviceTelemetryTopic).append('\'');
-        sb.append(", resourceTelemetryTopic='").append(resourceTelemetryTopic).append('\'');
-        sb.append(", eventTopic='").append(eventTopic).append('\'');
-        sb.append(", commandRequestTopic='").append(commandRequestTopic).append('\'');
-        sb.append(", commandResponseTopic='").append(commandResponseTopic).append('\'');
-        sb.append(", deviceTelemetryProcessingStepList=").append(deviceTelemetryProcessingStepList);
-        sb.append(", resourceTelemetryProcessingStepList=").append(resourceTelemetryProcessingStepList);
-        sb.append(", eventProcessingStepList=").append(eventProcessingStepList);
-        sb.append(", commandRequestProcessingStepList=").append(commandRequestProcessingStepList);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
@@ -14,6 +14,7 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
 
     private int outgoingClientQoS = 0;
 
+    //TODO Check if it is correctly used or can be improved
     private boolean outgoingClientRetainedMessages = false;
 
     private String destinationBrokerAddress;
@@ -24,30 +25,42 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
 
     private String deviceId = null;
 
-    private List<String> resourceIdList = null;
-
-    private String deviceTelemetryTopic = null;
-
-    private String resourceTelemetryTopic = null;
-
-    private String eventTopic = null;
-
-    private String commandRequestTopic = null;
-
-    private String commandResponseTopic = null;
-
     private String brokerAddress = "127.0.0.1";
 
     private int brokerPort = 1883;
 
     private boolean brokerLocal = true;
 
+    private List<MqttTopicDescriptor> topicList;
+
+    @Deprecated
+    private List<String> resourceIdList = null;
+
+    @Deprecated
+    private String deviceTelemetryTopic = null;
+
+    @Deprecated
+    private String resourceTelemetryTopic = null;
+
+    @Deprecated
+    private String eventTopic = null;
+
+    @Deprecated
+    private String commandRequestTopic = null;
+
+    @Deprecated
+    private String commandResponseTopic = null;
+
+    @Deprecated
     private List<String> deviceTelemetryProcessingStepList = null;
 
+    @Deprecated
     private List<String> resourceTelemetryProcessingStepList = null;
 
+    @Deprecated
     private List<String> eventProcessingStepList = null;
 
+    @Deprecated
     private List<String> commandRequestProcessingStepList = null;
 
     public Mqtt2MqttConfiguration() {
@@ -181,57 +194,78 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
         this.brokerLocal = brokerLocal;
     }
 
+    @Deprecated
     public List<String> getDeviceTelemetryProcessingStepList() {
         return deviceTelemetryProcessingStepList;
     }
 
+    @Deprecated
     public void setDeviceTelemetryProcessingStepList(List<String> deviceTelemetryProcessingStepList) {
         this.deviceTelemetryProcessingStepList = deviceTelemetryProcessingStepList;
     }
 
+    @Deprecated
     public List<String> getResourceTelemetryProcessingStepList() {
         return resourceTelemetryProcessingStepList;
     }
 
+    @Deprecated
     public void setResourceTelemetryProcessingStepList(List<String> resourceTelemetryProcessingStepList) {
         this.resourceTelemetryProcessingStepList = resourceTelemetryProcessingStepList;
     }
 
+    @Deprecated
     public List<String> getEventProcessingStepList() {
         return eventProcessingStepList;
     }
 
+    @Deprecated
     public void setEventProcessingStepList(List<String> eventProcessingStepList) {
         this.eventProcessingStepList = eventProcessingStepList;
     }
 
+    @Deprecated
     public List<String> getCommandRequestProcessingStepList() {
         return commandRequestProcessingStepList;
     }
 
+    @Deprecated
     public void setCommandRequestProcessingStepList(List<String> commandRequestProcessingStepList) {
         this.commandRequestProcessingStepList = commandRequestProcessingStepList;
     }
 
+    public List<MqttTopicDescriptor> getTopicList() {
+        return topicList;
+    }
+
+    public void setTopicList(List<MqttTopicDescriptor> topicList) {
+        this.topicList = topicList;
+    }
+
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("MqttProtocolConfiguration{");
-        sb.append("mqttDestinationBrokerAddress='").append(destinationBrokerAddress).append('\'');
-        sb.append(", mqttDestinationBrokerPort=").append(destinationBrokerPort);
-        sb.append(", mqttDestinationBrokerBaseTopic='").append(destinationBrokerBaseTopic).append('\'');
-        sb.append(", mqttOutgoingClientQoS=").append(outgoingClientQoS);
-        sb.append(", mqttOutgoingClientRetainedMessages=").append(outgoingClientRetainedMessages);
-        sb.append(", mqttOutgoingPublishingEnabled=").append(outgoingPublishingEnabled);
+        final StringBuffer sb = new StringBuffer("Mqtt2MqttConfiguration{");
+        sb.append("outgoingPublishingEnabled=").append(outgoingPublishingEnabled);
+        sb.append(", outgoingClientQoS=").append(outgoingClientQoS);
+        sb.append(", outgoingClientRetainedMessages=").append(outgoingClientRetainedMessages);
+        sb.append(", destinationBrokerAddress='").append(destinationBrokerAddress).append('\'');
+        sb.append(", destinationBrokerPort=").append(destinationBrokerPort);
+        sb.append(", destinationBrokerBaseTopic='").append(destinationBrokerBaseTopic).append('\'');
         sb.append(", deviceId='").append(deviceId).append('\'');
-        sb.append(", resourceList=").append(resourceIdList);
-        sb.append(", telemetryDeviceTopic='").append(deviceTelemetryTopic).append('\'');
-        sb.append(", telemetryResourceTopic='").append(resourceTelemetryTopic).append('\'');
+        sb.append(", brokerAddress='").append(brokerAddress).append('\'');
+        sb.append(", brokerPort=").append(brokerPort);
+        sb.append(", brokerLocal=").append(brokerLocal);
+        sb.append(", topicList=").append(topicList);
+        sb.append(", resourceIdList=").append(resourceIdList);
+        sb.append(", deviceTelemetryTopic='").append(deviceTelemetryTopic).append('\'');
+        sb.append(", resourceTelemetryTopic='").append(resourceTelemetryTopic).append('\'');
         sb.append(", eventTopic='").append(eventTopic).append('\'');
         sb.append(", commandRequestTopic='").append(commandRequestTopic).append('\'');
         sb.append(", commandResponseTopic='").append(commandResponseTopic).append('\'');
-        sb.append(", brokerAddress='").append(brokerAddress).append('\'');
-        sb.append(", brokerPortTopic=").append(brokerPort);
-        sb.append(", brokerLocal=").append(brokerLocal);
+        sb.append(", deviceTelemetryProcessingStepList=").append(deviceTelemetryProcessingStepList);
+        sb.append(", resourceTelemetryProcessingStepList=").append(resourceTelemetryProcessingStepList);
+        sb.append(", eventProcessingStepList=").append(eventProcessingStepList);
+        sb.append(", commandRequestProcessingStepList=").append(commandRequestProcessingStepList);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttConfiguration.java
@@ -12,7 +12,7 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
 
     private boolean dtForwardingEnabled = true;
 
-    private int outgoingClientQoS = 0;
+    private int dtPublishingQoS = 0;
 
     private String destinationBrokerAddress;
 
@@ -60,12 +60,12 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
         this.dtTopicPrefix = dtTopicPrefix;
     }
 
-    public int getOutgoingClientQoS() {
-        return outgoingClientQoS;
+    public int getDtPublishingQoS() {
+        return dtPublishingQoS;
     }
 
-    public void setOutgoingClientQoS(int outgoingClientQoS) {
-        this.outgoingClientQoS = outgoingClientQoS;
+    public void setDtPublishingQoS(int dtPublishingQoS) {
+        this.dtPublishingQoS = dtPublishingQoS;
     }
 
     public boolean getDtForwardingEnabled() {
@@ -120,7 +120,7 @@ public class Mqtt2MqttConfiguration implements WldtWorkerConfiguration {
     public String toString() {
         final StringBuffer sb = new StringBuffer("Mqtt2MqttConfiguration{");
         sb.append("dtForwardingEnabled=").append(dtForwardingEnabled);
-        sb.append(", outgoingClientQoS=").append(outgoingClientQoS);
+        sb.append(", dtPublishingQoS=").append(dtPublishingQoS);
         sb.append(", destinationBrokerAddress='").append(destinationBrokerAddress).append('\'');
         sb.append(", destinationBrokerPort=").append(destinationBrokerPort);
         sb.append(", dtTopicPrefix='").append(dtTopicPrefix).append('\'');

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
@@ -306,7 +306,7 @@ public class Mqtt2MqttManager {
 
             if (mqttClient.isConnected() && topic != null && payload.length > 0) {
                 MqttMessage msg = new MqttMessage(payload);
-                msg.setQos(this.mqtt2MqttConfiguration.getOutgoingClientQoS());
+                msg.setQos(this.mqtt2MqttConfiguration.getDtPublishingQoS());
                 msg.setRetained(isRetained);
                 mqttClient.publish(topic,msg);
                 logger.debug("Data Correctly Published !");

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
@@ -114,11 +114,6 @@ public class Mqtt2MqttManager {
 
             initTopicManagement();
 
-            //Init telemetry and event management
-            //TODO this methods in the next version
-            //this.initTelemetryMessageManagement();
-            //this.initEventMessageManagement();
-
             //Notify device correctly mirrored
             this.mqtt2MqttWorker.notifyDeviceMirrored(this.mqtt2MqttConfiguration.getDeviceId(), new HashMap<String, Object>() {
                 {
@@ -136,6 +131,9 @@ public class Mqtt2MqttManager {
 
     }
 
+    /**
+     * Handle how the DT's worker subscribe and register to target topics (both incoming and outgoing)
+     */
     private void initTopicManagement() {
 
         Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_TOPIC_REGISTRATION_TIME);
@@ -267,6 +265,15 @@ public class Mqtt2MqttManager {
         }
     }
 
+    /**
+     * Register to the target topic with the specified MqttClient
+     *
+     * @param mqttClient
+     * @param topic
+     * @param mqttMessageListener
+     * @throws WldtMqttModuleException
+     * @throws MqttException
+     */
     private void registerToMqttTopic(IMqttClient mqttClient, String topic, IMqttMessageListener mqttMessageListener) throws WldtMqttModuleException, MqttException {
 
         if(mqttClient != null && mqttClient.isConnected())
@@ -275,6 +282,16 @@ public class Mqtt2MqttManager {
             throw new WldtMqttModuleException("MQTT Client = NULL or Not Connected ! Impossible to subscribe to a target topic !");
     }
 
+    /**
+     *
+     * Publish data to the target topic using the specified MQTT Client
+     *
+     * @param mqttClient
+     * @param topic
+     * @param payload
+     * @param isRetained
+     * @throws MqttException
+     */
     private void publishData(IMqttClient mqttClient, String topic, byte[] payload, boolean isRetained) throws MqttException {
 
         Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_OUTGOING_PUBLISH_DATA_TIME);
@@ -302,6 +319,13 @@ public class Mqtt2MqttManager {
         }
     }
 
+    /**
+     *
+     * Build the outgoing topic adding (if configured) the DT prefix
+     *
+     * @param originalTopic
+     * @return
+     */
     private String getOutgoingTopic(String originalTopic){
 
         //If the topic prefix is not configured
@@ -314,6 +338,13 @@ public class Mqtt2MqttManager {
 
     }
 
+    /**
+     *
+     * Convert an incoming topic from DT to the original device by removing (if necessary) the DT's topic prefix
+     *
+     * @param dtIncomingTopic
+     * @return
+     */
     private String getDeviceIncomingTopicFromDigital(String dtIncomingTopic){
 
         //If the topic prefix is not configured
@@ -327,6 +358,13 @@ public class Mqtt2MqttManager {
             return dtIncomingTopic;
     }
 
+    /**
+     *
+     * Build the DT's incoming topic adding (if configured) the DT prefix
+     *
+     * @param originalTopic
+     * @return
+     */
     private String getDigitalTwinIncomingTopic(String originalTopic){
 
         //If the topic prefix is not configured
@@ -338,6 +376,13 @@ public class Mqtt2MqttManager {
             return String.format("%s/%s", mqtt2MqttConfiguration.getDtTopicPrefix(), originalTopic);
     }
 
+    /**
+     *
+     * Implement how the worker handle a new incoming message from the target topic
+     *
+     * @param topic
+     * @param msg
+     */
     private void handleIncomingMessage(String topic, MqttMessage msg) {
 
         Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_FORWARD_TIME);
@@ -375,10 +420,22 @@ public class Mqtt2MqttManager {
         }
     }
 
+    /**
+     *
+     * Build Broker Address associated to the physical device
+     *
+     * @return
+     */
     private String getPhysicalThingMqttBrokerUrl(){
         return String.format("tcp://%s:%d",this.mqtt2MqttConfiguration.getBrokerAddress(), this.mqtt2MqttConfiguration.getBrokerPort());
     }
 
+    /**
+     *
+     * Build Broker Address associated to digital twins
+     *
+     * @return
+     */
     private String getDestinationMqttBrokerUrl(){
 
         if(this.mqtt2MqttConfiguration.getDestinationBrokerAddress() == null)

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttManager.java
@@ -11,10 +11,11 @@ import org.eclipse.paho.client.mqttv3.*;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Author: Marco Picone, Ph.D. (marco.picone@unimore.it)
@@ -34,12 +35,12 @@ public class Mqtt2MqttManager {
     /**
      * MQTT Client to received data from the "physical" twin
      */
-    private IMqttClient incomingMqttClient;
+    private IMqttClient physicalDeviceMqttBrokerClient;
 
     /**
      * MQTT Client to send data to a destination broker
      */
-    private IMqttClient outgoingMqttClient;
+    private IMqttClient digitalTwinMqttBrokerClient;
 
     /**
      * Reference to the Mqtt2MqttWorker
@@ -64,6 +65,8 @@ public class Mqtt2MqttManager {
      */
     private String deviceEventTopic = null;
 
+    private Map<String, MqttTopicDescriptor> configuredTopicMap;
+
     private Mqtt2MqttManager(){
 
     }
@@ -81,306 +84,194 @@ public class Mqtt2MqttManager {
             this.mqtt2MqttConfiguration = mqtt2MqttConfiguration;
             this.wldtId = wldtId;
             this.mqtt2MqttWorker = mqtt2MqttWorker;
-
-            //TODO CHECK AND REMOVE IF NEEDED
-            //initProcessingPipelines();
-
+            this.configuredTopicMap = new HashMap<>();
         }
         else
             throw new WldtMqttModuleException("DTDPMqttProtocol configuration error ! Missing Broker Info or Device Id. Remote Broker are not yet supported");
 
     }
 
-    /*
-    private void initProcessingPipelines() {
+    /**
+     * Initialize both incoming and outgoind MQTT Clients
+     */
+    public void init() throws WldtMqttModuleException {
 
-        ProcessingStepLoader processingStepLoader = new ProcessingStepLoader();
+        try{
 
-        //Load Device Telemetry Processing Pipeline
-        if(this.mqtt2MqttConfiguration.getDeviceTelemetryProcessingStepList() != null && this.mqtt2MqttConfiguration.getDeviceTelemetryProcessingStepList().size() > 0){
-
-            this.deviceTelemetryprocessingPipeline = new ProcessingPipeline();
-
-            this.mqtt2MqttConfiguration.getDeviceTelemetryProcessingStepList().forEach(pipelineStepName -> {
-                this.deviceTelemetryprocessingPipeline.addStep(processingStepLoader.loadAnnotated(pipelineStepName));
-            });
-
-            logger.info("Device Telemetry Processing Pipeline Initialized ! Step Size: {}", this.deviceTelemetryprocessingPipeline.getSize());
-        }
-
-        //Load Resource Telemetry Processing Pipeline
-        if(this.mqtt2MqttConfiguration.getResourceTelemetryProcessingStepList() != null && this.mqtt2MqttConfiguration.getResourceTelemetryProcessingStepList().size() > 0){
-
-            this.resourceTelemetryprocessingPipeline = new ProcessingPipeline();
-
-            this.mqtt2MqttConfiguration.getResourceTelemetryProcessingStepList().forEach(pipelineStepName -> {
-                this.resourceTelemetryprocessingPipeline.addStep(processingStepLoader.loadAnnotated(pipelineStepName));
-            });
-
-            logger.info("Resource Telemetry Processing Pipeline Initialized ! Step Size: {}", this.resourceTelemetryprocessingPipeline.getSize());
-        }
-
-        //Load Event Telemetry Processing Pipeline
-        if(this.mqtt2MqttConfiguration.getEventProcessingStepList() != null && this.mqtt2MqttConfiguration.getEventProcessingStepList().size() > 0){
-
-            this.eventTelemetryprocessingPipeline = new ProcessingPipeline();
-
-            this.mqtt2MqttConfiguration.getEventProcessingStepList().forEach(pipelineStepName -> {
-                this.eventTelemetryprocessingPipeline.addStep(processingStepLoader.loadAnnotated(pipelineStepName));
-            });
-
-            logger.info("Resource Telemetry Processing Pipeline Initialized ! Step Size: {}", this.eventTelemetryprocessingPipeline.getSize());
-        }
-    }
-    */
-
-    public void initCommandMessageManagement() {
-
-    }
-
-    public void initEventMessageManagement() throws MqttException, WldtMqttModuleException, IOException{
-
-
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_TOPIC_REGISTRATION_TIME);
-
-        try {
-
-            if(this.mqtt2MqttConfiguration.getEventTopic() != null){
-                deviceEventTopic = TopicTemplateManager.getTopicForDevice(this.mqtt2MqttConfiguration.getEventTopic(), this.mqtt2MqttConfiguration.getDeviceId());
-                registerToIncomingMqttTopic(deviceEventTopic, this::handleEventMessage);
-                logger.info("{} Registered to Device Event Topic: {}", TAG, deviceEventTopic);
+            //Init MQTT Incoming client
+            if(this.mqtt2MqttConfiguration != null) {
+                logger.info("{} Initializing Incoming MQTT Client ...", TAG);
+                initPhysicalDeviceMqttBrokerClient();
             }
             else
-                logger.info("Event Topic Configuration = null ! Avoiding registering to the topic ...");
+                logger.info("{} Mqtt2MqttConfiguration = null ! Impossible to init the Incoming MQTT Client", TAG);
 
-        } finally {
-            if(context != null)
-                context.stop();
+            //Init MQTT Outgoing client
+            if(this.mqtt2MqttConfiguration.getOutgoingPublishingEnabled() &&
+                    this.mqtt2MqttConfiguration.getDestinationBrokerAddress() != null &&
+                    this.mqtt2MqttConfiguration.getDestinationBrokerPort() > 0) {
+                logger.info("{} Initializing Outgoing MQTT Client ...", TAG);
+                initDigitalTwinMqttBrokerClient();
+            }
+            else
+                logger.info("{} Destination Broker Configuration Error ! Impossible to init the Outgoing MQTT Client", TAG);
+
+            initTopicManagement();
+
+            //Init telemetry and event management
+            //TODO this methods in the next version
+            //this.initTelemetryMessageManagement();
+            //this.initEventMessageManagement();
+
+            //Notify device correctly mirrored
+            this.mqtt2MqttWorker.notifyDeviceMirrored(this.mqtt2MqttConfiguration.getDeviceId(), new HashMap<String, Object>() {
+                {
+                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_ID, mqtt2MqttConfiguration.getDeviceId());
+                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_TOPIC_NUMBER, configuredTopicMap.size());
+                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_TOPIC_LIST, configuredTopicMap.keySet().stream().map(String::valueOf).collect(Collectors.joining("-", "{", "}")));
+                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_BROKER_ENDPOINT_CALLBACK_METADATA, getPhysicalThingMqttBrokerUrl());
+                }
+            });
+
+        }catch (Exception e){
+            this.mqtt2MqttWorker.notifyDeviceMirroringError(this.mqtt2MqttConfiguration.getDeviceId(), e.getLocalizedMessage());
+            throw new WldtMqttModuleException(e.getLocalizedMessage());
         }
+
     }
 
-    public void initTelemetryMessageManagement() throws MqttException, WldtMqttModuleException, IOException, WldtWorkerException {
+    private void initTopicManagement() {
 
         Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_TOPIC_REGISTRATION_TIME);
 
         try {
 
-            if(this.mqtt2MqttConfiguration.getDeviceTelemetryTopic() != null){
+            //Check if topics are correctly configured
+            if(this.mqtt2MqttConfiguration.getTopicList() != null && this.mqtt2MqttConfiguration.getTopicList().size() > 0){
 
-                deviceTelemetryTopic = TopicTemplateManager.getTopicForDevice(this.mqtt2MqttConfiguration.getDeviceTelemetryTopic(), this.mqtt2MqttConfiguration.getDeviceId());
-                registerToIncomingMqttTopic(deviceTelemetryTopic, this::handleDeviceTelemetryMessage);
+                //Analyze each configured topic
+                this.mqtt2MqttConfiguration.getTopicList().forEach(mqttTopicDescriptor -> {
+                    try{
+                        //Check if Id and topic are correctly configured
+                        if(mqttTopicDescriptor.getId() != null && mqttTopicDescriptor.getId().length() > 0 && mqttTopicDescriptor.getTopic() != null && mqttTopicDescriptor.getTopic().length() > 0) {
 
-                logger.info("{} Registered to Device Telemetry Topic: {}", TAG, deviceTelemetryTopic);
+                            //Build final target topic in order to apply templates (if required)
+                            String targetTopic = null;
 
-                if(this.mqtt2MqttConfiguration.getResourceTelemetryTopic() != null){
-                    //Handle Telemetry topic for available device's resources
-                    if(this.mqtt2MqttConfiguration.getResourceIdList() != null && this.mqtt2MqttConfiguration.getResourceIdList().size() > 0){
+                            if(mqttTopicDescriptor.getResourceId() != null && mqttTopicDescriptor.getResourceId().length() > 0)
+                                targetTopic = TopicTemplateManager.getTopicForDeviceResource(mqttTopicDescriptor.getTopic(), this.mqtt2MqttConfiguration.getDeviceId(), mqttTopicDescriptor.getResourceId());
+                            else
+                                targetTopic = TopicTemplateManager.getTopicForDevice(mqttTopicDescriptor.getTopic(), this.mqtt2MqttConfiguration.getDeviceId());
 
-                        this.mqtt2MqttConfiguration.getResourceIdList().forEach(resourceId -> {
-                            try {
-                                String resourceTelemetryTopic = TopicTemplateManager.getTopicForDeviceResource(this.mqtt2MqttConfiguration.getResourceTelemetryTopic(), this.mqtt2MqttConfiguration.getDeviceId(), resourceId);
-                                registerToIncomingMqttTopic(resourceTelemetryTopic, this::handleResourceTelemetryMessage);
+                            IMqttClient targetMqttClient = null;
 
-                                //Notify resource correctly mirrored
-                                this.mqtt2MqttWorker.notifyResourceMirrored(this.mqtt2MqttConfiguration.getDeviceId(), new HashMap<String, Object>() {
+                            //Select the right mqttClient according to topic configuration
+                            if (mqttTopicDescriptor.getType().equals(MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_OUTGOING))
+                                targetMqttClient = physicalDeviceMqttBrokerClient;
+                            else if (mqttTopicDescriptor.getType().equals(MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_INCOMING))
+                                targetMqttClient = digitalTwinMqttBrokerClient;
+
+                            if (targetMqttClient != null) {
+
+                                //Register to the target MQTT topic on the right client
+                                registerToMqttTopic(targetMqttClient, targetTopic, this::handleIncomingMessage);
+
+                                //Save the configured topic and its descriptor in order to properly use the configuration when a new message is received
+                                configuredTopicMap.put(targetTopic, mqttTopicDescriptor);
+
+                                //Notify that the resource (topic in that case) has been correctly mirrored
+                                String finalTargetTopic = targetTopic;
+                                this.mqtt2MqttWorker.notifyResourceMirrored((mqttTopicDescriptor.getResourceId() == null ? mqttTopicDescriptor.getId() : mqttTopicDescriptor.getResourceId()), new HashMap<String, Object>() {
                                     {
-                                        put(Mqtt2MqttWorker.RESOURCE_MIRRORED_TELEMETRY_TOPIC_CALLBACK_METADATA, resourceTelemetryTopic);
+                                        put(Mqtt2MqttWorker.RESOURCE_MIRRORED_TOPIC_CALLBACK_METADATA, finalTargetTopic);
                                         put(Mqtt2MqttWorker.DEVICE_MIRRORED_BROKER_ENDPOINT_CALLBACK_METADATA, getPhysicalThingMqttBrokerUrl());
                                     }
                                 });
 
-                                logger.info("{} Registered to ResourceId Telemetry Topic: {}", TAG, resourceTelemetryTopic);
-
-                            } catch (WldtMqttModuleException | MqttException | IOException | WldtWorkerException e) {
-                                String errorMsg = String.format("%s Error registering for resourceId: %s telemetry topics ! Exception: %s", TAG, resourceId, e.getLocalizedMessage());
-                                logger.error(errorMsg);
-                                this.mqtt2MqttWorker.notifyDeviceMirroringError(this.mqtt2MqttConfiguration.getDeviceId(), errorMsg);
-                                isMirroringCompleted = false;
+                                logger.info("{} Registered to Configured topic with id: {} and value: {}", TAG, mqttTopicDescriptor.getId(), targetTopic);
                             }
-                        });
+                            else
+                                logger.error("Topic Configuration Error (Type not found !) ! Configured record: {}", mqttTopicDescriptor);
+
+                        }  else
+                            logger.error("Topic Configuration Error ! Configured record: {}", mqttTopicDescriptor);
+
+                    }catch (Exception e){
+                        String errorMsg = String.format("%s Error registering to target topic: %s ! Exception: %s", TAG, mqttTopicDescriptor.getTopic(), e.getLocalizedMessage());
+                        logger.error(errorMsg);
+                        mqtt2MqttWorker.notifyResourceMirroringError(mqtt2MqttConfiguration.getDeviceId(), errorMsg);
+                        isMirroringCompleted = false;
                     }
-                }
-                else
-                    logger.info("Resource Telemetry Topic Configuration = null ! Avoiding registering to the topic ...");
+                });
 
             }else
-                logger.info("Device Telemetry Topic Configuration = null ! Avoiding registering to the topic ...");
+                logger.info("Topic List Configuration = null or Empty ! Avoiding registering to the topics ...");
 
         } finally {
             if(context != null)
                 context.stop();
         }
+
     }
 
+    /**
+     * Initialize the MQTT Consumer to send and receive data and command from and to the Physical Thing
+     */
+    public void initPhysicalDeviceMqttBrokerClient() throws MqttException {
 
-    private void handleEventMessage(String topic, MqttMessage msg) {
-
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_EVENT_FORWARD_TIME);
-
-        try {
-            byte[] payload = msg.getPayload();
-
-            WldtMetricsManager.getInstance().measureMqttIncomingPayloadSizeMetric(payload.length);
-            WldtMetricsManager.getInstance().measureMqttIncomingEventPayloadSizeMetric(payload.length);
-
-            logger.debug("{} EVENT TOPIC ({}) Message Received: {}", TAG, topic, new String(payload));
-
-            if(mqtt2MqttConfiguration.getOutgoingPublishingEnabled()){
-
-                if(this.getMqtt2MqttWorker() != null && this.getMqtt2MqttWorker().hasProcessingPipeline(Mqtt2MqttWorker.DEFAULT_EVENT_PIPELINE)){
-
-                    logger.info("Executing Processing Pipeline ({}) for topic: {} ...", Mqtt2MqttWorker.DEFAULT_EVENT_PIPELINE, topic);
-
-                    this.getMqtt2MqttWorker().executeProcessingPipeline(Mqtt2MqttWorker.DEFAULT_EVENT_PIPELINE, new MqttPipelineData(topic, payload), new ProcessingPipelineListener() {
-
-                        @Override
-                        public void onPipelineDone(Optional<PipelineData> result) {
-
-                            if(result.isPresent() && result.get() instanceof MqttPipelineData){
-                                try {
-                                    MqttPipelineData processingInfo = (MqttPipelineData)result.get();
-                                    publishData(outgoingMqttClient, getOutgoingTopic(processingInfo.getTopic()), processingInfo.getPayload());
-                                }catch (Exception e){
-                                    e.printStackTrace();
-                                }
-                            }
-                            else
-                                logger.warn("MQTT Processing Pipeline produced an empty result for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                        @Override
-                        public void onPipelineError() {
-                            logger.error("Error MQTT Processing Pipeline for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                    });
-
-                }
-                else
-                    publishData(outgoingMqttClient, getOutgoingTopic(topic), payload);
-            }
-
-        }catch (Exception e){
-            logger.error("{} ERROR FORWARDING MESSAGE TO TOPIC: {}", TAG, topic);
-        } finally {
-            if(context != null)
-                context.stop();
-        }
-    }
-
-    private void handleDeviceTelemetryMessage(String topic, MqttMessage msg) {
-
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_TELEMETRY_FORWARD_TIME);
+        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_INCOMING_CLIENT_SETUP_TIME);
 
         try {
 
-            byte[] payload = msg.getPayload();
-            WldtMetricsManager.getInstance().measureMqttIncomingPayloadSizeMetric(payload.length);
-            WldtMetricsManager.getInstance().measureMqttIncomingTelemetryPayload(payload.length);
+            physicalDeviceMqttBrokerClient = new MqttClient(getPhysicalThingMqttBrokerUrl(),String.format("%s%s", this.wldtId, "physical"), new MemoryPersistence());
 
-            logger.debug("{} DEVICE TELEMETRY TOPIC ({}) Message Received: {}", TAG, topic, new String(payload));
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setAutomaticReconnect(true);
+            options.setCleanSession(true);
+            options.setConnectionTimeout(10);
+            physicalDeviceMqttBrokerClient.connect(options);
 
-            if(mqtt2MqttConfiguration.getOutgoingPublishingEnabled()){
-
-                if(this.getMqtt2MqttWorker() != null && this.getMqtt2MqttWorker().hasProcessingPipeline(Mqtt2MqttWorker.DEFAULT_DEVICE_TELEMETRY_PROCESSING_PIPELINE)){
-
-                    logger.info("Executing Processing Pipeline ({}) for topic: {} ...", Mqtt2MqttWorker.DEFAULT_DEVICE_TELEMETRY_PROCESSING_PIPELINE, topic);
-
-                    this.getMqtt2MqttWorker().executeProcessingPipeline(Mqtt2MqttWorker.DEFAULT_DEVICE_TELEMETRY_PROCESSING_PIPELINE, new MqttPipelineData(topic, payload), new ProcessingPipelineListener() {
-
-                        @Override
-                        public void onPipelineDone(Optional<PipelineData> result) {
-
-                            if(result.isPresent() && result.get() instanceof MqttPipelineData){
-                                try {
-                                    MqttPipelineData processingInfo = (MqttPipelineData) result.get();
-                                    publishData(outgoingMqttClient, getOutgoingTopic(processingInfo.getTopic()), processingInfo.getPayload());
-                                }catch (Exception e){
-                                    e.printStackTrace();
-                                }
-                            }
-                            else
-                                logger.warn("MQTT Processing Pipeline produced an empty result for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                        @Override
-                        public void onPipelineError() {
-                            logger.error("Error MQTT Processing Pipeline for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                    });
-                }
-                else
-                    publishData(outgoingMqttClient, getOutgoingTopic(topic), payload);
-            }
+            logger.info("{} INCOMING MQTT Client Connected to {}", TAG, getPhysicalThingMqttBrokerUrl());
 
         }catch (Exception e){
-            logger.error("{} ERROR FORWARDING TELEMETRY MESSAGE TO TOPIC: {}", TAG, topic);
+            throw e;
         } finally {
             if(context != null)
                 context.stop();
         }
     }
 
-    private void handleResourceTelemetryMessage(String topic, MqttMessage msg) {
+    /**
+     * Initialize the MQTT Client to send and receive data and command to external broker
+     */
+    public void initDigitalTwinMqttBrokerClient() throws MqttException {
 
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_TELEMETRY_FORWARD_TIME);
+        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_OUTGOING_CLIENT_SETUP_TIME);
 
         try {
 
-            byte[] payload = msg.getPayload();
+            digitalTwinMqttBrokerClient = new MqttClient(getDestinationMqttBrokerUrl(),String.format("%s%s", this.wldtId, "digital"), new MemoryPersistence());
 
-            WldtMetricsManager.getInstance().measureMqttIncomingPayloadSizeMetric(payload.length);
-            WldtMetricsManager.getInstance().measureMqttIncomingTelemetryPayload(payload.length);
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setAutomaticReconnect(true);
+            options.setCleanSession(true);
+            options.setConnectionTimeout(10);
+            digitalTwinMqttBrokerClient.connect(options);
 
-            logger.debug("{} RESOURCE TELEMETRY TOPIC ({}) Message Received: {}", TAG, topic, new String(payload));
-
-            if(mqtt2MqttConfiguration.getOutgoingPublishingEnabled()){
-
-                if(this.getMqtt2MqttWorker() != null && this.getMqtt2MqttWorker().hasProcessingPipeline(Mqtt2MqttWorker.DEFAULT_RESOURCE_TELEMETRY_PROCESSING_PIPELINE)){
-
-                    logger.info("Executing Processing Pipeline ({}) for topic: {} ...", Mqtt2MqttWorker.DEFAULT_RESOURCE_TELEMETRY_PROCESSING_PIPELINE, topic);
-
-                    this.getMqtt2MqttWorker().executeProcessingPipeline(Mqtt2MqttWorker.DEFAULT_RESOURCE_TELEMETRY_PROCESSING_PIPELINE, new MqttPipelineData(topic, payload), new ProcessingPipelineListener() {
-
-                        @Override
-                        public void onPipelineDone(Optional<PipelineData> result) {
-
-                            if(result.isPresent() && result.get() instanceof MqttPipelineData){
-                                try {
-                                    MqttPipelineData processingInfo = (MqttPipelineData)result.get();
-                                    publishData(outgoingMqttClient, getOutgoingTopic(processingInfo.getTopic()), processingInfo.getPayload());
-                                }catch (Exception e){
-                                    e.printStackTrace();
-                                }
-                            }
-                            else
-                                logger.warn("MQTT Processing Pipeline produced an empty result for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                        @Override
-                        public void onPipelineError() {
-                            logger.error("Error MQTT Processing Pipeline for Topic: {} ! Skipping data forwarding !", topic);
-                        }
-
-                    });
-                }
-                else
-                    publishData(outgoingMqttClient, getOutgoingTopic(topic), payload);
-            }
+            logger.info("{} OUTGOING MQTT Client Connected to {}", TAG, getDestinationMqttBrokerUrl());
 
         }catch (Exception e){
-            logger.error("{} ERROR FORWARDING TELEMETRY MESSAGE TO TOPIC: {}", TAG, topic);
+            throw e;
         } finally {
             if(context != null)
                 context.stop();
         }
     }
 
-    private void registerToIncomingMqttTopic(String topic, IMqttMessageListener mqttMessageListener) throws WldtMqttModuleException, MqttException {
+    private void registerToMqttTopic(IMqttClient mqttClient, String topic, IMqttMessageListener mqttMessageListener) throws WldtMqttModuleException, MqttException {
 
-        if(incomingMqttClient != null && incomingMqttClient.isConnected())
-            incomingMqttClient.subscribe(topic, mqttMessageListener);
+        if(mqttClient != null && mqttClient.isConnected())
+            mqttClient.subscribe(topic, mqttMessageListener);
         else
             throw new WldtMqttModuleException("MQTT Client = NULL or Not Connected ! Impossible to subscribe to a target topic !");
     }
@@ -412,105 +303,6 @@ public class Mqtt2MqttManager {
         }
     }
 
-    /**
-     * Initialize both incoming and outgoind MQTT Clients
-     */
-    public void init() throws WldtMqttModuleException {
-
-        try{
-
-            if(this.mqtt2MqttConfiguration != null) {
-                logger.info("{} Initializing Incoming MQTT Client ...", TAG);
-                initIncomingClient();
-            }
-            else
-                logger.info("{} DTDPMqttProtocol = null ! Impossible to init the Incoming MQTT Client", TAG);
-
-            if(this.mqtt2MqttConfiguration.getOutgoingPublishingEnabled() &&
-                    this.mqtt2MqttConfiguration.getDestinationBrokerAddress() != null &&
-                    this.mqtt2MqttConfiguration.getDestinationBrokerPort() > 0) {
-                logger.info("{} Initializing Outgoing MQTT Client ...", TAG);
-                initOutgoingClient();
-            }
-            else
-                logger.info("{} Destination Broker Configuration Error ! Impossible to init the Outgoing MQTT Client", TAG);
-
-            //Init telemetry and event managemenet
-            this.initTelemetryMessageManagement();
-            this.initEventMessageManagement();
-
-            //TODO Command and Responses topics management should be implemented
-
-            //Notify device correctly mirrored
-            this.mqtt2MqttWorker.notifyDeviceMirrored(this.mqtt2MqttConfiguration.getDeviceId(), new HashMap<String, Object>() {
-                {
-                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_TELEMETRY_TOPIC_CALLBACK_METADATA, deviceTelemetryTopic);
-                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_EVENT_TOPIC_CALLBACK_METADATA, deviceEventTopic);
-                    put(Mqtt2MqttWorker.DEVICE_MIRRORED_BROKER_ENDPOINT_CALLBACK_METADATA, getPhysicalThingMqttBrokerUrl());
-                }
-            });
-
-        }catch (Exception e){
-            this.mqtt2MqttWorker.notifyDeviceMirroringError(this.mqtt2MqttConfiguration.getDeviceId(), e.getLocalizedMessage());
-            throw new WldtMqttModuleException(e.getLocalizedMessage());
-        }
-
-    }
-
-    /**
-     * Initialize the MQTT Consumer to send and receive data and command from and to the Physical Thing
-     */
-    public void initIncomingClient() throws MqttException {
-
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_INCOMING_CLIENT_SETUP_TIME);
-
-        try {
-
-            incomingMqttClient = new MqttClient(getPhysicalThingMqttBrokerUrl(),String.format("%s%s", this.wldtId, "incoming"), new MemoryPersistence());
-
-            MqttConnectOptions options = new MqttConnectOptions();
-            options.setAutomaticReconnect(true);
-            options.setCleanSession(true);
-            options.setConnectionTimeout(10);
-            incomingMqttClient.connect(options);
-
-            logger.info("{} INCOMING MQTT Client Connected to {}", TAG, getPhysicalThingMqttBrokerUrl());
-
-        }catch (Exception e){
-            throw e;
-        } finally {
-            if(context != null)
-                context.stop();
-        }
-    }
-
-    /**
-     * Initialize the MQTT Client to send and receive data and command to external broker
-     */
-    public void initOutgoingClient() throws MqttException {
-
-        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_OUTGOING_CLIENT_SETUP_TIME);
-
-        try {
-
-            outgoingMqttClient = new MqttClient(getDestinationMqttBrokerUrl(),String.format("%s%s", this.wldtId, "outgoing"), new MemoryPersistence());
-
-            MqttConnectOptions options = new MqttConnectOptions();
-            options.setAutomaticReconnect(true);
-            options.setCleanSession(true);
-            options.setConnectionTimeout(10);
-            outgoingMqttClient.connect(options);
-
-            logger.info("{} OUTGOING MQTT Client Connected to {}", TAG, getDestinationMqttBrokerUrl());
-
-        }catch (Exception e){
-            throw e;
-        } finally {
-            if(context != null)
-                context.stop();
-        }
-    }
-
     private String getOutgoingTopic(String originalTopic){
         if(mqtt2MqttConfiguration.getDestinationBrokerBaseTopic() == null ||
                 mqtt2MqttConfiguration.getDestinationBrokerBaseTopic().equals("null") ||
@@ -518,6 +310,44 @@ public class Mqtt2MqttManager {
             return originalTopic;
         else
             return String.format("%s/%s", mqtt2MqttConfiguration.getDestinationBrokerBaseTopic(), originalTopic);
+    }
+
+    private void handleIncomingMessage(String topic, MqttMessage msg) {
+
+        Timer.Context context = WldtMetricsManager.getInstance().getMqttModuleTimerContext(WldtMetricsManager.MQTT_FORWARD_TIME);
+
+        try {
+
+            byte[] payload = msg.getPayload();
+            WldtMetricsManager.getInstance().measureMqttIncomingPayloadSizeMetric(payload.length);
+            WldtMetricsManager.getInstance().measureMqttIncomingTelemetryPayload(payload.length);
+
+            logger.debug("{} DEVICE TOPIC ({}) Message Received: {}", TAG, topic, new String(payload));
+
+            //TODO rename that field -> Forwarding Enabled ?
+            if(mqtt2MqttConfiguration.getOutgoingPublishingEnabled()){
+
+                MqttTopicDescriptor configuredMqttTopicDescriptor = configuredTopicMap.get(topic);
+
+                //TODO add processing pipeline support
+                if(configuredMqttTopicDescriptor != null){
+                    if(configuredMqttTopicDescriptor.getType().equals(MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_OUTGOING))
+                        publishData(digitalTwinMqttBrokerClient, getOutgoingTopic(topic), payload);
+                    else if(configuredMqttTopicDescriptor.getType().equals(MqttTopicDescriptor.MQTT_TOPIC_TYPE_DEVICE_INCOMING))
+                        publishData(physicalDeviceMqttBrokerClient, getOutgoingTopic(topic), payload);
+
+                }
+                else
+                    logger.error("{} MqttTopicDescriptor not found ! ERROR FORWARDING TELEMETRY MESSAGE TO TOPIC: {}", TAG, topic);
+
+            }
+
+        }catch (Exception e){
+            logger.error("{} ERROR FORWARDING TELEMETRY MESSAGE TO TOPIC: {}", TAG, topic);
+        } finally {
+            if(context != null)
+                context.stop();
+        }
     }
 
     private String getPhysicalThingMqttBrokerUrl(){

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttWorker.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttWorker.java
@@ -1,7 +1,6 @@
 package it.unimore.dipi.iot.wldt.worker.mqtt;
 
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
-import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.exception.*;
 import it.unimore.dipi.iot.wldt.worker.WldtWorker;
 import it.unimore.dipi.iot.wldt.utils.WldtUtils;
@@ -20,21 +19,26 @@ public class Mqtt2MqttWorker extends WldtWorker<Mqtt2MqttConfiguration, Void, Vo
 
     private static final Logger logger = LoggerFactory.getLogger(Mqtt2MqttWorker.class);
 
-    private static final String TAG = "[WLDT-MQTT-WORKER]";
+    private static final String TAG = "[WLDT-MQTT2MQTT-WORKER]";
 
     private static final String CONF_FILE_NAME = "mqtt.yaml";
 
+    @Deprecated
     public static final String DEFAULT_DEVICE_TELEMETRY_PROCESSING_PIPELINE = "mqtt_default_device_telemetry_processing_pipeline";
 
+    @Deprecated
     public static final String DEFAULT_RESOURCE_TELEMETRY_PROCESSING_PIPELINE = "mqtt_default_resource_telemetry_processing_pipeline";
 
+    @Deprecated
     public static final String DEFAULT_EVENT_PIPELINE = "mqtt_default_event_processing_pipeline";
 
-    public static final String DEVICE_MIRRORED_TELEMETRY_TOPIC_CALLBACK_METADATA = "mqtt_device_telemetry_topic";
+    public static final String DEVICE_MIRRORED_ID = "mqtt_device_id";
 
-    public static final String DEVICE_MIRRORED_EVENT_TOPIC_CALLBACK_METADATA = "mqtt_device_event_topic";
+    public static final String DEVICE_MIRRORED_TOPIC_NUMBER = "mqtt_mirrored_topic_number";
 
-    public static final String RESOURCE_MIRRORED_TELEMETRY_TOPIC_CALLBACK_METADATA = "mqtt_resource_telemetry_topic";
+    public static final String DEVICE_MIRRORED_TOPIC_LIST = "mqtt_mirrored_topic_list";
+
+    public static final String RESOURCE_MIRRORED_TOPIC_CALLBACK_METADATA = "mqtt_resource_topic";
 
     public static final String DEVICE_MIRRORED_BROKER_ENDPOINT_CALLBACK_METADATA = "mqtt_broker_endpoint";
 
@@ -51,7 +55,7 @@ public class Mqtt2MqttWorker extends WldtWorker<Mqtt2MqttConfiguration, Void, Vo
         this.wldtId = wldtId;
     }
 
-    public Mqtt2MqttWorker(String wldtId, WldtConfiguration wldtConfiguration) throws WldtConfigurationException {
+    public Mqtt2MqttWorker(String wldtId) throws WldtConfigurationException {
         this.wldtId = wldtId;
         this.setWldtWorkerConfiguration((Mqtt2MqttConfiguration) WldtUtils.readConfigurationFile(WldtEngine.WLDT_CONFIGURATION_FOLDER, CONF_FILE_NAME, Mqtt2MqttConfiguration.class));
 
@@ -66,16 +70,13 @@ public class Mqtt2MqttWorker extends WldtWorker<Mqtt2MqttConfiguration, Void, Vo
                 || this.getWldtWorkerConfiguration().getDestinationBrokerPort() <= 0
                 || this.getWldtWorkerConfiguration().getBrokerAddress() == null
                 || this.getWldtWorkerConfiguration().getBrokerPort() <= 0
-                || (this.getWldtWorkerConfiguration().getDeviceTelemetryTopic() == null
-                    && this.getWldtWorkerConfiguration().getResourceTelemetryTopic() == null
-                    && this.getWldtWorkerConfiguration().getEventTopic() == null
-                    && this.getWldtWorkerConfiguration().getCommandRequestTopic() == null)
+                || this.getWldtWorkerConfiguration().getTopicList() == null
         )
-            throw new WldtConfigurationException("WldtCoapWorker -> Worker Configuration = null or required parameters are missing!");
+            throw new WldtConfigurationException("Mqtt2MqttWorker -> Worker Configuration = null or required parameters are missing!");
 
         try{
             startMqttProtocolManagement();
-        }catch (Exception | WldtMqttModuleException e){
+        }catch (Exception e){
             e.printStackTrace();
             String errorMsg = String.format("MQTT PROTOCOL MANAGER Runtime Error: %s", e.getLocalizedMessage());
             logger.debug("{} {}", TAG, errorMsg);

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttWorker.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/Mqtt2MqttWorker.java
@@ -2,6 +2,7 @@ package it.unimore.dipi.iot.wldt.worker.mqtt;
 
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
 import it.unimore.dipi.iot.wldt.exception.*;
+import it.unimore.dipi.iot.wldt.processing.IProcessingPipeline;
 import it.unimore.dipi.iot.wldt.worker.WldtWorker;
 import it.unimore.dipi.iot.wldt.utils.WldtUtils;
 import org.eclipse.paho.client.mqttv3.MqttException;
@@ -22,15 +23,6 @@ public class Mqtt2MqttWorker extends WldtWorker<Mqtt2MqttConfiguration, Void, Vo
     private static final String TAG = "[WLDT-MQTT2MQTT-WORKER]";
 
     private static final String CONF_FILE_NAME = "mqtt.yaml";
-
-    @Deprecated
-    public static final String DEFAULT_DEVICE_TELEMETRY_PROCESSING_PIPELINE = "mqtt_default_device_telemetry_processing_pipeline";
-
-    @Deprecated
-    public static final String DEFAULT_RESOURCE_TELEMETRY_PROCESSING_PIPELINE = "mqtt_default_resource_telemetry_processing_pipeline";
-
-    @Deprecated
-    public static final String DEFAULT_EVENT_PIPELINE = "mqtt_default_event_processing_pipeline";
 
     public static final String DEVICE_MIRRORED_ID = "mqtt_device_id";
 
@@ -101,6 +93,10 @@ public class Mqtt2MqttWorker extends WldtWorker<Mqtt2MqttConfiguration, Void, Vo
         else
             logger.error("MQTT Manager already associated to an existing MQTT Device ({}:{}) ! No Action !", this.mqtt2MqttManager.getMqtt2MqttConfiguration().getBrokerAddress(), this.mqtt2MqttManager.getMqtt2MqttConfiguration().getBrokerPort());
 
+    }
+
+    public void addTopicProcessingPipeline(String configuredTopicId, IProcessingPipeline newProcessingPipeline) throws ProcessingPipelineException {
+        super.addProcessingPipeline(configuredTopicId, newProcessingPipeline);
     }
 
     public Mqtt2MqttManager getMqtt2MqttManager() {

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/MqttPipelineData.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/MqttPipelineData.java
@@ -6,13 +6,25 @@ public class MqttPipelineData implements PipelineData {
 
     private String topic;
     private byte[] payload;
+    private MqttTopicDescriptor mqttTopicDescriptor = null;
+    private boolean isRetained = false;
 
     public MqttPipelineData() {
     }
 
-    public MqttPipelineData(String topic, byte[] payload) {
+    public MqttPipelineData(String topic, MqttTopicDescriptor mqttTopicDescriptor, byte[] payload, boolean isRetained) {
         this.topic = topic;
         this.payload = payload;
+        this.mqttTopicDescriptor = mqttTopicDescriptor;
+        this.isRetained = isRetained;
+    }
+
+    public MqttTopicDescriptor getMqttTopicDescriptor() {
+        return mqttTopicDescriptor;
+    }
+
+    public void setMqttTopicDescriptor(MqttTopicDescriptor mqttTopicDescriptor) {
+        this.mqttTopicDescriptor = mqttTopicDescriptor;
     }
 
     public String getTopic() {
@@ -31,9 +43,17 @@ public class MqttPipelineData implements PipelineData {
         this.payload = payload;
     }
 
+    public boolean isRetained() {
+        return isRetained;
+    }
+
+    public void setRetained(boolean retained) {
+        isRetained = retained;
+    }
+
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("MqttProcessingInfo{");
+        final StringBuffer sb = new StringBuffer("MqttPipelineData{");
         sb.append("topic='").append(topic).append('\'');
         sb.append(", payload=");
         if (payload == null) sb.append("null");
@@ -43,6 +63,8 @@ public class MqttPipelineData implements PipelineData {
                 sb.append(i == 0 ? "" : ", ").append(payload[i]);
             sb.append(']');
         }
+        sb.append(", mqttTopicDescriptor=").append(mqttTopicDescriptor);
+        sb.append(", isRetained=").append(isRetained);
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/MqttTopicDescriptor.java
+++ b/src/main/java/it/unimore/dipi/iot/wldt/worker/mqtt/MqttTopicDescriptor.java
@@ -1,0 +1,74 @@
+package it.unimore.dipi.iot.wldt.worker.mqtt;
+
+/**
+ * @author Marco Picone, Ph.D. - picone.m@gmail.com
+ * @project wldt-core
+ * @created 09/03/2021 - 15:48
+ */
+public class MqttTopicDescriptor {
+
+    public static String MQTT_TOPIC_TYPE_DEVICE_OUTGOING = "device_outgoing";
+
+    public static String MQTT_TOPIC_TYPE_DEVICE_INCOMING = "device_incoming";
+
+    private String id;
+
+    private String resourceId;
+
+    private String topic;
+
+    private String type;
+
+    public MqttTopicDescriptor() {
+    }
+
+    public MqttTopicDescriptor(String id, String resourceId, String topic, String type) {
+        this.id = id;
+        this.resourceId = resourceId;
+        this.topic = topic;
+        this.type = type;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("MqttTopicDescriptor{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", resourceId='").append(resourceId).append('\'');
+        sb.append(", topic='").append(topic).append('\'');
+        sb.append(", type='").append(type).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/test/java/it/unimore/wldt/test/coap/TestCoapProcess.java
+++ b/src/test/java/it/unimore/wldt/test/coap/TestCoapProcess.java
@@ -2,8 +2,6 @@ package it.unimore.wldt.test.coap;
 
 import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
-import it.unimore.dipi.iot.wldt.exception.WldtConfigurationException;
-import it.unimore.dipi.iot.wldt.process.WldtCoapProcess;
 import it.unimore.dipi.iot.wldt.processing.ProcessingPipeline;
 import it.unimore.dipi.iot.wldt.worker.coap.Coap2CoapConfiguration;
 import it.unimore.dipi.iot.wldt.worker.coap.Coap2CoapWorker;

--- a/src/test/java/it/unimore/wldt/test/coap/TestCoapProcess.java
+++ b/src/test/java/it/unimore/wldt/test/coap/TestCoapProcess.java
@@ -43,7 +43,7 @@ public class TestCoapProcess {
             wldtEngine.addNewWorker(coap2CoapWorker);
             wldtEngine.startWorkers();
 
-        }catch (Exception | WldtConfigurationException e){
+        }catch (Exception e){
             e.printStackTrace();
         }
     }

--- a/src/test/java/it/unimore/wldt/test/coap/WldtCoapProcess.java
+++ b/src/test/java/it/unimore/wldt/test/coap/WldtCoapProcess.java
@@ -1,8 +1,7 @@
-package it.unimore.dipi.iot.wldt.process;
+package it.unimore.wldt.test.coap;
 
 import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
-import it.unimore.dipi.iot.wldt.exception.WldtConfigurationException;
 import it.unimore.dipi.iot.wldt.worker.coap.Coap2CoapConfiguration;
 import it.unimore.dipi.iot.wldt.worker.coap.Coap2CoapWorker;
 import org.slf4j.Logger;

--- a/src/test/java/it/unimore/wldt/test/dummy/WldtDummyProcess.java
+++ b/src/test/java/it/unimore/wldt/test/dummy/WldtDummyProcess.java
@@ -1,9 +1,8 @@
-package it.unimore.dipi.iot.wldt.process;
+package it.unimore.wldt.test.dummy;
 
 import it.unimore.dipi.iot.wldt.cache.WldtCache;
 import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
-import it.unimore.dipi.iot.wldt.exception.WldtConfigurationException;
 import it.unimore.dipi.iot.wldt.processing.ProcessingPipeline;
 import it.unimore.dipi.iot.wldt.worker.dummy.DummyProcessingStep;
 import it.unimore.dipi.iot.wldt.worker.dummy.DummyWorkerConfiguration;

--- a/src/test/java/it/unimore/wldt/test/mqtt/DemoDataStructure.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/DemoDataStructure.java
@@ -1,0 +1,65 @@
+package it.unimore.wldt.test.mqtt;
+
+/**
+ * @author Marco Picone, Ph.D. - picone.m@gmail.com
+ * @project wldt-core
+ * @created 10/03/2021 - 12:48
+ */
+public class DemoDataStructure {
+
+    private String type = "demo_data_structure";
+
+    private long timestamp;
+
+    private String originalMessage;
+
+    public DemoDataStructure(byte[] originalPayload) {
+        this.timestamp = System.currentTimeMillis();
+        this.originalMessage = new String(originalPayload);
+    }
+
+    public DemoDataStructure(String originalMessage) {
+        this.timestamp = System.currentTimeMillis();
+        this.originalMessage = originalMessage;
+    }
+
+    public DemoDataStructure(String type, long timestamp, String originalMessage) {
+        this.type = type;
+        this.timestamp = timestamp;
+        this.originalMessage = originalMessage;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+
+    public void setOriginalMessage(String originalMessage) {
+        this.originalMessage = originalMessage;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("DemoDataStructure{");
+        sb.append("type='").append(type).append('\'');
+        sb.append(", timestamp=").append(timestamp);
+        sb.append(", originalMessage='").append(originalMessage).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/test/java/it/unimore/wldt/test/mqtt/MqttPayloadChangeStep.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/MqttPayloadChangeStep.java
@@ -1,0 +1,72 @@
+package it.unimore.wldt.test.mqtt;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.unimore.dipi.iot.wldt.processing.PipelineData;
+import it.unimore.dipi.iot.wldt.processing.ProcessingStep;
+import it.unimore.dipi.iot.wldt.processing.ProcessingStepListener;
+import it.unimore.dipi.iot.wldt.processing.cache.PipelineCache;
+import it.unimore.dipi.iot.wldt.worker.mqtt.MqttPipelineData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.util.Objects;
+import java.util.Optional;
+
+@Named("MqttAverageProcessingStep")
+public class MqttPayloadChangeStep implements ProcessingStep {
+
+    private static final Logger logger = LoggerFactory.getLogger(MqttPayloadChangeStep.class);
+
+    private final static String PIPELINE_CACHE_VALUE_LIST = "value_list";
+
+    private ObjectMapper mapper;
+
+    public MqttPayloadChangeStep() {
+        this.mapper = new ObjectMapper();
+        this.mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    }
+
+    @Override
+    public void execute(PipelineCache pipelineCache, PipelineData incomingData, ProcessingStepListener listener) {
+
+        MqttPipelineData data = null;
+
+        if(incomingData instanceof MqttPipelineData)
+            data = (MqttPipelineData)incomingData;
+        else if(listener != null)
+            listener.onStepError(this, incomingData, String.format("Wrong PipelineData for MqttAverageProcessingStep ! Data type: %s", incomingData.getClass()));
+        else
+            logger.error("Wrong PipelineData for MqttAverageProcessingStep ! Data type: {}", incomingData.getClass());
+
+        try{
+
+            if(listener != null && Objects.requireNonNull(data).getPayload() != null) {
+                listener.onStepDone(this, Optional.of(new MqttPipelineData(data.getTopic(), data.getMqttTopicDescriptor(), mapper.writeValueAsBytes(new DemoDataStructure(data.getPayload())), data.isRetained())));
+            }
+            else
+                logger.error("Processing Step Listener or MqttProcessingInfo Data = Null ! Skipping processing step");
+
+        }catch (Exception e){
+            logger.error("MQTT Processing Step Error: {}", e.getLocalizedMessage());
+
+            if(listener != null)
+                listener.onStepError(this, data, e.getLocalizedMessage());
+        }
+    }
+
+
+    private static boolean isNumeric(String strNum) {
+        if (strNum == null) {
+            return false;
+        }
+        try {
+            double d = Double.parseDouble(strNum);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/test/java/it/unimore/wldt/test/mqtt/MqttSenmlBuilderProcessingStep.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/MqttSenmlBuilderProcessingStep.java
@@ -1,24 +1,28 @@
-package it.unimore.dipi.iot.wldt.processing.step;
+package it.unimore.wldt.test.mqtt;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.unimore.dipi.iot.wldt.processing.PipelineData;
 import it.unimore.dipi.iot.wldt.processing.cache.PipelineCache;
 import it.unimore.dipi.iot.wldt.processing.ProcessingStep;
 import it.unimore.dipi.iot.wldt.processing.ProcessingStepListener;
 import it.unimore.dipi.iot.wldt.worker.mqtt.MqttPipelineData;
+import it.unimore.dipi.iot.wldt.utils.SenML;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.util.ArrayList;
-import java.util.Optional;
 import javax.inject.Named;
+import java.util.Optional;
 
-@Named("MqttAverageProcessingStep")
-public class MqttAverageProcessingStep implements ProcessingStep {
+@Named("MqttSenmlBuilderProcessingStep")
+public class MqttSenmlBuilderProcessingStep implements ProcessingStep {
 
-    private static final Logger logger = LoggerFactory.getLogger(MqttAverageProcessingStep.class);
+    private static final Logger logger = LoggerFactory.getLogger(MqttSenmlBuilderProcessingStep.class);
 
-    private final static String PIPELINE_CACHE_VALUE_LIST = "value_list";
+    private ObjectMapper mapper;
 
-    public MqttAverageProcessingStep() {
+    public MqttSenmlBuilderProcessingStep() {
+        this.mapper = new ObjectMapper();
+        this.mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
     @Override
@@ -35,37 +39,18 @@ public class MqttAverageProcessingStep implements ProcessingStep {
 
         try{
 
-            if(listener != null && data.getPayload() != null){
+            if(listener != null && data != null && data.getPayload() != null){
 
                 String payloadBodyString = new String(data.getPayload());
 
                 if(isNumeric(payloadBodyString)){
-
                     Double bodyDoubleValue = Double.parseDouble(payloadBodyString);
+                    Optional<String> newPayload = buildSenmlDataPayload(data.getTopic(), bodyDoubleValue);
 
-                    //Init Pipeline Cache
-                    if(pipelineCache.getData(this, PIPELINE_CACHE_VALUE_LIST) == null)
-                        pipelineCache.addData(this, PIPELINE_CACHE_VALUE_LIST, new ArrayList<Double>());
-
-                    ArrayList<Double> valueList = (ArrayList<Double>) pipelineCache.getData(this, PIPELINE_CACHE_VALUE_LIST);
-                    valueList.add(bodyDoubleValue);
-
-                    logger.info("Cached list size: {}", valueList.size());
-
-                    if(valueList.size() == 10){
-
-                        double sum = valueList.stream().mapToDouble(value -> value).sum();
-                        double average = sum / (double)valueList.size();
-
-                        valueList.clear();
-                        pipelineCache.addData(this, PIPELINE_CACHE_VALUE_LIST, valueList);
-
-                        listener.onStepDone(this, java.util.Optional.of(new MqttPipelineData(String.format("%s/%s", data.getTopic(), "average"), Double.toString(average).getBytes())));
-                    }
-                    else{
-                        pipelineCache.addData(this, PIPELINE_CACHE_VALUE_LIST, valueList);
-                        listener.onStepDone(this, Optional.empty());
-                    }
+                    if(newPayload.isPresent())
+                        listener.onStepDone(this, Optional.of(new MqttPipelineData(data.getTopic(), data.getMqttTopicDescriptor(), newPayload.get().getBytes(), data.isRetained())));
+                    else
+                        listener.onStepError(this, data, "Error processing the data ! Processing Error ...");
                 }
                 else
                     listener.onStepError(this, data, "Provided Payload is not a Number ! Skipping processing ....");
@@ -82,6 +67,24 @@ public class MqttAverageProcessingStep implements ProcessingStep {
         }
     }
 
+    private Optional<String> buildSenmlDataPayload(String topic, Double doubleValue){
+
+        try{
+
+            SenML senmlData = new SenML();
+
+            senmlData.setBaseName(topic);
+            senmlData.setName(topic);
+            senmlData.setValue(doubleValue);
+            senmlData.setUpdateTime(System.currentTimeMillis());
+
+            return Optional.of(this.mapper.writeValueAsString(senmlData));
+
+        }catch (Exception e){
+            logger.error("Error building SENML Data ! Error: {}", e.getLocalizedMessage());
+            return Optional.empty();
+        }
+    }
 
     private static boolean isNumeric(String strNum) {
         if (strNum == null) {

--- a/src/test/java/it/unimore/wldt/test/mqtt/MqttTopicChangeStep.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/MqttTopicChangeStep.java
@@ -1,0 +1,68 @@
+package it.unimore.wldt.test.mqtt;
+
+import it.unimore.dipi.iot.wldt.processing.PipelineData;
+import it.unimore.dipi.iot.wldt.processing.ProcessingStep;
+import it.unimore.dipi.iot.wldt.processing.ProcessingStepListener;
+import it.unimore.dipi.iot.wldt.processing.cache.PipelineCache;
+import it.unimore.dipi.iot.wldt.worker.mqtt.MqttPipelineData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
+
+@Named("MqttAverageProcessingStep")
+public class MqttTopicChangeStep implements ProcessingStep {
+
+    private static final Logger logger = LoggerFactory.getLogger(MqttTopicChangeStep.class);
+
+    private final static String PIPELINE_CACHE_VALUE_LIST = "value_list";
+
+    public MqttTopicChangeStep() {
+    }
+
+    @Override
+    public void execute(PipelineCache pipelineCache, PipelineData incomingData, ProcessingStepListener listener) {
+
+        MqttPipelineData data = null;
+
+        if(incomingData instanceof MqttPipelineData)
+            data = (MqttPipelineData)incomingData;
+        else if(listener != null)
+            listener.onStepError(this, incomingData, String.format("Wrong PipelineData for MqttAverageProcessingStep ! Data type: %s", incomingData.getClass()));
+        else
+            logger.error("Wrong PipelineData for MqttAverageProcessingStep ! Data type: {}", incomingData.getClass());
+
+        try{
+
+            if(listener != null && Objects.requireNonNull(data).getPayload() != null) {
+                String newTopic = String.format("%s/%s", "pipeline", data.getTopic());
+                listener.onStepDone(this, Optional.of(new MqttPipelineData(newTopic, data.getMqttTopicDescriptor(), data.getPayload(), data.isRetained())));
+            }
+            else
+                logger.error("Processing Step Listener or MqttProcessingInfo Data = Null ! Skipping processing step");
+
+        }catch (Exception e){
+            logger.error("MQTT Processing Step Error: {}", e.getLocalizedMessage());
+
+            if(listener != null)
+                listener.onStepError(this, data, e.getLocalizedMessage());
+        }
+    }
+
+
+    private static boolean isNumeric(String strNum) {
+        if (strNum == null) {
+            return false;
+        }
+        try {
+            double d = Double.parseDouble(strNum);
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/test/java/it/unimore/wldt/test/mqtt/WldtMqttProcess.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/WldtMqttProcess.java
@@ -102,7 +102,7 @@ public class WldtMqttProcess {
 
         Mqtt2MqttConfiguration mqtt2MqttConfiguration = new Mqtt2MqttConfiguration();
 
-        mqtt2MqttConfiguration.setOutgoingClientQoS(0);
+        mqtt2MqttConfiguration.setDtPublishingQoS(0);
         mqtt2MqttConfiguration.setDestinationBrokerAddress("127.0.0.1");
         mqtt2MqttConfiguration.setDestinationBrokerPort(1884);
         mqtt2MqttConfiguration.setDtTopicPrefix("wldt");

--- a/src/test/java/it/unimore/wldt/test/mqtt/WldtMqttProcess.java
+++ b/src/test/java/it/unimore/wldt/test/mqtt/WldtMqttProcess.java
@@ -1,7 +1,9 @@
-package it.unimore.dipi.iot.wldt.process;
+package it.unimore.wldt.test.mqtt;
 
 import it.unimore.dipi.iot.wldt.engine.WldtConfiguration;
 import it.unimore.dipi.iot.wldt.engine.WldtEngine;
+import it.unimore.dipi.iot.wldt.processing.ProcessingPipeline;
+import it.unimore.dipi.iot.wldt.processing.step.IdentityProcessingStep;
 import it.unimore.dipi.iot.wldt.worker.MirroringListener;
 import it.unimore.dipi.iot.wldt.worker.mqtt.Mqtt2MqttConfiguration;
 import it.unimore.dipi.iot.wldt.worker.mqtt.Mqtt2MqttWorker;
@@ -43,6 +45,24 @@ public class WldtMqttProcess {
             WldtEngine wldtEngine = new WldtEngine(wldtConfiguration);
 
             Mqtt2MqttWorker mqtt2MqttWorker = new Mqtt2MqttWorker(wldtEngine.getWldtId(), getMqttComplexProtocolConfiguration());
+
+            //Add Processing Pipeline for target topics
+            mqtt2MqttWorker.addTopicProcessingPipeline("DummyStringResource",
+                    new ProcessingPipeline(
+                        new IdentityProcessingStep(),
+                        new MqttPayloadChangeStep(),
+                        new MqttTopicChangeStep()
+                    )
+            );
+
+            mqtt2MqttWorker.addTopicProcessingPipeline("CommandChannel",
+                    new ProcessingPipeline(
+                            new IdentityProcessingStep(),
+                            new MqttPayloadChangeStep()
+                    )
+            );
+
+            //Add Mirroring Listener
             mqtt2MqttWorker.addMirroringListener(new MirroringListener() {
 
                 @Override
@@ -110,8 +130,6 @@ public class WldtMqttProcess {
         //mqtt2MqttConfiguration.setEventTopic("events/{{device_id}}");
         //mqtt2MqttConfiguration.setCommandRequestTopic("commands/{{device_id}}/request");
         //mqtt2MqttConfiguration.setCommandResponseTopic("commands/{{device_id}}/response");
-
-
 
         return mqtt2MqttConfiguration;
     }


### PR DESCRIPTION
Huge refactoring of the Mqtt2Mqtt Worker. Now it supports:

- Generic topic configuration both incoming and outgoing topics (e.g., telemetry and commands) without the need to respect a specific target structure
- Possibility to configure a dedicated ProcessingPipeline for each topic
- Support for retained messages
- Simplified Mqtt2MqttWorkerConfiguration